### PR TITLE
Removed occurrences of "bits" header and replaced with individual includes

### DIFF
--- a/ImageRead.hpp
+++ b/ImageRead.hpp
@@ -1,7 +1,7 @@
 #ifndef IMAGEREAD_HPP
 #define IMAGEREAD_HPP
 
-#include <bits/stdc++.h>
+#include <iostream>
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 using namespace std;

--- a/ImageWrite.hpp
+++ b/ImageWrite.hpp
@@ -1,7 +1,7 @@
 #ifndef IMAGEWRITE_HPP
 #define IMAGEWRITE_HPP
 
-#include <bits/stdc++.h>
+#include <iostream>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 using namespace std;

--- a/compressor.cpp
+++ b/compressor.cpp
@@ -1,4 +1,4 @@
-#include <bits/stdc++.h>
+#include <iostream>
 #include <chrono>
 #include "ImageRead.hpp"
 #include "ImageWrite.hpp"


### PR DESCRIPTION
Removed all occurrences of <bits/stdc++> header as it is not officially supported in some versions. Replaced them with individual includes instead.