### PR TITLE
Modify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Image compression is done using the k-means algorithm, pixel values are grouped 
 1. Clone the repo with `git clone https://github.com/DebadityaPal/k-means-compressor`
 2. Run the software with CLI commands
 The CLI commands are:
-`gcc -std=C++17 compressor.cpp <args>`
+`g++ -std=c++17 compressor.cpp <args>`
 
 ## Usage
 The arguments are listed below


### PR DESCRIPTION
Fixes issue #8

The documentation contained -
gcc -std=C++17 compressor.cpp
for compiling the program, this however does not work due to linking issues and hence the documentation needed to be updated.

Changed to - 
g++ -std=c++17 compressor.cpp